### PR TITLE
The "read" flag cookie didn't have a path set, in some case you would

### DIFF
--- a/alfresco-systemmessages-share/src/main/resources/META-INF/redpill/components/global/notifications.js
+++ b/alfresco-systemmessages-share/src/main/resources/META-INF/redpill/components/global/notifications.js
@@ -61,7 +61,8 @@ SystemNotifications.prototype.setRemovalCookie = function(id,msg) {
        expiryDate = new Date(msg.endTime);
     }
     Cookie.set("deletednotifications" + id, "read", {
-        expires:  expiryDate
+        expires:  expiryDate,
+        path: "/"
     });
 };
 


### PR DESCRIPTION
have to dismiss the message more than once. Seem to work in Chrome
without this change, but Safari and IE it can show up even if marked
as "read"

Setting the path to "/" ensures the cookie is set for all pages.